### PR TITLE
Optionally, only process push events to the default branch

### DIFF
--- a/config.json.0
+++ b/config.json.0
@@ -7,6 +7,9 @@
         "topic_id": 0
     },
     "onebox_enabled": false,
+    "repository": {
+        "default_branch_only": true
+    },
     "webhook": {
         "path": "",
         "port": 8080,

--- a/g2d.js
+++ b/g2d.js
@@ -53,9 +53,22 @@ http.createServer(function (req, res) {
 
 handler.on('push', function(event) {
 
-    console.log("Received push from " +
-        event.payload["repository"]["full_name"])
+    // Extract some parameters from event payload.
+    var repository_name = event.payload["repository"]["full_name"]
+    var default_branch = event.payload["repository"]["default_branch"]
+    var target_ref = event.payload["ref"]
     var commits = event.payload.commits
+
+    console.log("Received push from " + repository_name)
+
+    // When configured, only process push events to the default branch.
+    if (config.repository && config.repository.default_branch_only) {
+        var default_branch_ref = "refs/heads/" + default_branch
+        if (target_ref != default_branch_ref) {
+            console.log("Ignoring push to non-default branch ref " + target_ref)
+            return
+        }
+    }
 
     // Handle multiple commits in one webhook
     for (var commit of commits) {


### PR DESCRIPTION
Dear @huw,

this is a minor patch which is intended to just process pushes to the repository's default branch. The behaviour is only active when `config.repository.default_branch_only` is set to `true`, so it doesn't change the behavior when upgrading the software without adjusting the configuration, essentially making it backwards-compatible.

With kind regards,
Andreas.
