### PR TITLE
Fix the forwarding order issue for multiple commits in a single webhook

### DIFF
--- a/g2d.js
+++ b/g2d.js
@@ -71,8 +71,12 @@ handler.on('push', function(event) {
     }
 
     // Handle multiple commits in one webhook
-    for (var commit of commits) {
+    if (!commits || commits.length === 0) return
 
+    function processCommit(index) {
+        if (index >= commits.length) return
+
+        var commit = commits[index]
         console.log("Processing commit '" + commit.id + "': " + commit.message)
 
         // BUILD THE MESSAGE
@@ -102,12 +106,20 @@ handler.on('push', function(event) {
                 ") - this is an automated post_"
         }
 
-        create_post(commit, comment_text)
+        create_post(commits[index], comment_text, function(err) {
+            if (err) {
+                // Log error but continue with next commit
+                console.error("Failed to post commit " + commits[index].id + ": " + err.message)
+            }
+            processCommit(index + 1)
+        })
+    }
 
-    };
+    processCommit(0)
+
 })
 
-function create_post(commit, comment_text) {
+function create_post(commit, comment_text, callback) {
 
         // http://learndiscourse.org/discourse-api-documentation/#posts
 
@@ -144,10 +156,12 @@ function create_post(commit, comment_text) {
             var response = JSON.parse(body)
             if (response.errors) {
                 console.error("Error posting commit '" + commit.id + "': " + response.errors)
+                if (callback) callback(new Error(response.errors.join(', ')))
             } else {
                 var post_url = discourse_url + "/t/" + config.discourse.topic_id +
                     "/" + JSON.parse(body).post_number
                 console.log("Success: " + commit.id + " / " + post_url)
+                if (callback) callback()
             }
         })
 


### PR DESCRIPTION
The previous handling method initiated all post creation requests simultaneously, which resulted in the final order of posts being inconsistent with the commit order in the GitHub repository when multiple commits were received in one webhook.

This Pull Request changes this behavior, ensuring that subsequent forwarding posts are created only after the earlier commits have been forwarded.

Comparison of the effect before and after the fix:
<img width="558" height="1795" alt="image" src="https://github.com/user-attachments/assets/d3927106-1627-4a30-8b9c-fb165c7a894f" />
